### PR TITLE
Fix touchscreen and WiFi

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Enjoy :)
 
 ## How to fix the touchscreen on a previous installation
 
-Warning: please back up your nand file. The isetup file should work on all sandcastle installations with the official nand image, but no guarantee.
+**Warning**: please back up your nand file. The isetup file should work on all sandcastle installations from the official nand image, but no guarantee.
 
-All you need to do is run the isetup script on your device. The script will detect if you have already installed sandcastle.
+All you need to do is run this isetup script on your device. The script will detect if you have already installed sandcastle.
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,19 @@
 # projectsandcastlefix
-Project Sandcastle will currently fail on iOS 14.4 and up, in this git repository is how to get it functional again. Included here is the new isetup file you need in order for setup to complete as well as other instructions
+The Android version of Project Sandcastle will currently fail on iOS 14.4 and up. This repository fixes that.
+A working isetup file and instructions are included.
+
+If you're trying to get Project Sandcastle working, I recommend [infinity](https://github.com/fullpwn/infinity) ([Latest release](https://github.com/fullpwn/infinity/releases/latest)).
+It's based off the isetup from this repo, but it's much more user friendly, and is currently the only way to get Sandcastle working for Windows users.
 
 
+## Manual installation instructions
 
-## Installation instructions
-
-* Download Project Sandcastle Android edition
-
+* Download and extract the Android version of [Project Sandcastle](https://projectsandcastle.org/status)
 * Jailbreak with current checkra1n
-
 * Replace the Sandcastle isetup file with the one in this git
-
-* Run ./setup.sh or otherwise run the isetup script on your device
-
-* Download checkra1n version 0.10.1
-
-* Run the start.sh. For linux users, there is an included start_linux.sh
+* Run `./setup.sh` or otherwise run the isetup script on your device
+* Download [checkra1n version 0.10.1](https://checkra.in/releases/0.10.1-beta) (actual download links are at the bottom of the page)
+* Run the `start.sh` script. For Linux users, there is an included `start_linux.sh` (more of a development tool, but it works).
 
 Enjoy :)
 
@@ -33,9 +31,8 @@ All you need to do is run this isetup script on your device. The script will det
 
 checkra1n 0.10.2 works sometimes but is inconsistent.
 
-checkra1n 0.11 crashes nto pongoOS.
+checkra1n 0.11 crashes to pongoOS.
 
 checkra1n 0.12-0.12.1 does not boot into pongoOS.
-
 
 checkra1n 0.12.2-present does not load the image into pongoOS.

--- a/README.md
+++ b/README.md
@@ -3,36 +3,39 @@ Project Sandcastle will currently fail on iOS 14.4 and up, in this git repositor
 
 
 
-INSTRUCTIONS
+## Installation instructions
 
-Download Project Sandbox Android edition
+* Download Project Sandcastle Android edition
 
-Jailbreak with current checkra1n
+* Jailbreak with current checkra1n
 
-Change the contained iSetup file with the one in this git
+* Replace the Sandcastle isetup file with the one in this git
 
-Run ./setup.sh
+* Run ./setup.sh or otherwise run the isetup script on your device
 
-Download checkra1n version 0.10.1
+* Download checkra1n version 0.10.1
 
-Run the start.sh
+* Run the start.sh. For linux users, there is an included start_linux.sh
 
 Enjoy :)
 
 
-KNOWN ISSUES
 
-checkra1n 0.10.2 works sometimes but is inconsistent
+## How to fix the touchscreen on a previous installation
 
-checkra1n 0.11 crashes nto pongoOS
+Warning: please back up your nand file. The isetup file should work on all sandcastle installations with the official nand image, but no guarantee.
 
-checkra1n 0.12-0.12.1 does not boot into pongoOS
-
-
-checkra1n 0.12.2-present does not load the image into pongoOS
+All you need to do is run the isetup script on your device. The script will detect if you have already installed sandcastle.
 
 
 
-Touchscreen functionality is not working currently
+## Known issues
 
-I have submitted an issue for Pongo to hopefully get the touchscreen functional (if it is a Pongo problem, may not be)
+checkra1n 0.10.2 works sometimes but is inconsistent.
+
+checkra1n 0.11 crashes nto pongoOS.
+
+checkra1n 0.12-0.12.1 does not boot into pongoOS.
+
+
+checkra1n 0.12.2-present does not load the image into pongoOS.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ Enjoy :)
 All you need to do is run this isetup script on your device. The script will detect if you have already installed sandcastle.
 
 
+## Uninstall Sandcastle
+
+Transfer to and run the iremove script on your device.
+
+
 
 ## Known issues
 

--- a/iremove
+++ b/iremove
@@ -1,0 +1,77 @@
+#!/bin/bash
+# This file is from https://github.com/Albert-S-Briscoe/projectsandcastlefix
+# Based on https://github.com/306bobby/projectsandcastlefix and https://projectsandcastle.org/
+
+
+# Check for an Android filesystem.
+
+LABEL=
+VOLUME=
+VOLUMES=`ls -1 /dev/disk0s1s* | sort -V`
+
+# Might as well leave this.
+if [[ -z $VOLUMES ]]; then
+	echo "Can't find any apfs volumes. Something is very wrong."
+	exit 1
+fi
+
+# Search for android volume
+for i in ${VOLUMES}; do
+	LABEL=`/System/Library/Filesystems/apfs.fs/apfs.util -p $i`
+	if [ "${LABEL}" == "Android" ]; then
+		VOLUME=$i
+		break
+	fi
+done
+if [ ! -b ${VOLUME} ]; then
+	echo "Cannot find Android volume. You probably haven't installed sandcastle."
+	exit 0
+fi
+
+
+echo "Mounting ${VOLUME}"
+mkdir -p /tmp/mnt
+mount -t apfs ${VOLUME} /tmp/mnt 
+if [ $? -ne 0 ]; then
+	echo "Failed to mount volume. Are you running as root?";
+	exit 1
+fi
+
+if [ ! -e /tmp/mnt/nand ]; then
+	echo "No nand file found. Sandcastle already uninstalled."
+	umount /tmp/mnt
+	echo "Unmounted /tmp/mnt"
+	exit 0
+fi
+
+# Check to make sure removing /tmp/mnt/usr won't break a ios install ...that happens to be in a volume named Android? I just want to be safe and not brick people's phones
+if [ -e /tmp/mnt/Library ]; then
+	echo "Either you did something incredibly strange with partitions or something is very wrong."
+	umount /tmp/mnt
+	echo "Unmounted /tmp/mnt"
+	exit 1
+fi
+
+
+
+
+# At this point, we've hopefully confirmed that the correct volume is mounted and there's a sandcastle nand on it.
+
+
+echo -n "This will free about 2gb. Are you sure you want to delete all Android files? (type yes to continue): "
+read -r CONFIRM
+if [ ! "$CONFIRM" == "yes" ]; then
+	umount /tmp/mnt
+	echo "Unmounted /tmp/mnt"
+	exit 0
+fi
+
+echo "Removing nand file..."
+rm -rf /tmp/mnt/nand
+
+# Remove firmware files
+rm -rf /tmp/mnt/usr
+sync
+
+umount /tmp/mnt
+echo "Sandcastle removed. Unmounted /tmp/mnt"

--- a/isetup
+++ b/isetup
@@ -1,51 +1,59 @@
 #!/bin/bash
 # This file is from https://github.com/Albert-S-Briscoe/projectsandcastlefix
+# Based on https://github.com/306bobby/projectsandcastlefix and https://projectsandcastle.org/
 
-DISK=0
-DISKS=`ls -1 /dev/disk0s1s* | sort -V`
 
-if [[ -z $DISKS ]]; then
-	# I can't find any way to delete accidentally created apfs volumes. This should help prevent making them in the first place.
+# Check for an Android filesystem, and create one if there isn't
+
+LABEL=
+VOLUME=
+VOLUMES=`ls -1 /dev/disk0s1s* | sort -V`
+
+# I can't find any way to delete accidentally created apfs volumes. This should help prevent making them in the first place.
+if [[ -z $VOLUMES ]]; then
 	echo "Can't find any apfs volumes. Something is very wrong."
 	exit 1
 fi
 
-# search for 
-for i in ${DISKS}
-do
+# Search for android volume
+for i in ${VOLUMES}; do
 	LABEL=`/System/Library/Filesystems/apfs.fs/apfs.util -p $i`
 	if [ "${LABEL}" == "Android" ]; then
-		DISK=$i
+		VOLUME=$i
 		break;
 	fi
 done
-if [ ! -b ${DISK} ]; then
+if [ ! -b ${VOLUME} ]; then
 	echo "Creating new Android volume"
 	newfs_apfs -A -v Android -e /dev/disk0s1
 fi
 
-DISK=
-DISKS=`ls /dev/disk0s1s* | sort -V`
 
-for i in ${DISKS}
-do
+# Double check that there's a valid filesystem
+
+LABEL=
+VOLUME=
+VOLUMES=`ls /dev/disk0s1s* | sort -V`
+
+for i in ${VOLUMES}; do
 	LABEL=`/System/Library/Filesystems/apfs.fs/apfs.util -p $i`
 	if [ "${LABEL}" == "Android" ]; then
-		DISK=$i
+		VOLUME=$i
 		break;
 	fi
 done
-
-if [ ! -b ${DISK} ]; then 
+if [ ! -b ${VOLUME} ]; then 
 	echo "Android volume not found. This should have been caught earlier"
 	exit 1
 fi
 
-echo "Mounting ${DISK}"
+
+
+echo "Mounting ${VOLUME}"
 mkdir -p /tmp/mnt
-mount -t apfs ${DISK} /tmp/mnt 
+mount -t apfs ${VOLUME} /tmp/mnt 
 if [ $? -ne 0 ]; then
-	echo "failed to mount volume. Are you running as root?";
+	echo "Failed to mount volume. Are you running as root?";
 	exit 1
 fi
 
@@ -53,7 +61,7 @@ if [ -e /tmp/mnt/nand ]; then
 	echo "Nand image already downloaded."
 else
 	rm -rf /tmp/mnt/nand
-	echo "Starting to download nand. This will take a few minutes"
+	echo "Starting download of the nand file. This will take a few minutes"
 	wget http://assets.checkra.in/downloads/sandcastle/88b1089d97fe72ab77af8253ab7c312f8e789d49209234239be2408c3ad89a34/nand.gz -O /tmp/mnt/nand.gz
 	if [ $? -ne 0 ]; then
 		echo "Failed to download nand. Are you connected to wifi?"
@@ -82,4 +90,4 @@ mkdir -p /tmp/mnt/usr/share/firmware/
 cp -rn /usr/share/firmware/* /tmp/mnt/usr/share/firmware/
 
 umount /tmp/mnt
-echo "unmounted /tmp/mnt"
+echo "Unmounted /tmp/mnt"

--- a/isetup
+++ b/isetup
@@ -1,77 +1,85 @@
 #!/bin/bash
+# This file is from https://github.com/Albert-S-Briscoe/projectsandcastlefix
 
 DISK=0
-DISKS=`ls -U /dev/disk0s1s*`
-echo "disks: $DISKS"
+DISKS=`ls -1 /dev/disk0s1s* | sort -V`
+
+if [[ -z $DISKS ]]; then
+	# I can't find any way to delete accidentally created apfs volumes. This should help prevent making them in the first place.
+	echo "Can't find any apfs volumes. Something is very wrong."
+	exit 1
+fi
+
+# search for 
+for i in ${DISKS}
+do
+	LABEL=`/System/Library/Filesystems/apfs.fs/apfs.util -p $i`
+	if [ "${LABEL}" == "Android" ]; then
+		DISK=$i
+		break;
+	fi
+done
+if [ ! -b ${DISK} ]; then
+	echo "Creating new Android volume"
+	newfs_apfs -A -v Android -e /dev/disk0s1
+fi
+
+DISK=
+DISKS=`ls /dev/disk0s1s* | sort -V`
 
 for i in ${DISKS}
 do
 	LABEL=`/System/Library/Filesystems/apfs.fs/apfs.util -p $i`
 	if [ "${LABEL}" == "Android" ]; then
 		DISK=$i
-		echo "found an Android volume"
 		break;
 	fi
 done
-if [ ! -b ${DISK} ]; then
-	newfs_apfs -A -v Android -e /dev/disk0s1
-fi
 
-DISK=
-DISKS=`ls /dev/disk0s1s*`
-
-for i in ${DISKS}
-do
-	LABEL=`/System/Library/Filesystems/apfs.fs/apfs.util -p $i`
-	if [ "${LABEL}" == "Android" ]; then
-		if [ $i != "/dev/disk0s1s10" ]; then
-			DISK=$i
-			echo "found volume $i"
-			break;
-		fi
-	fi
-done
-if [ -b ${DISK} ]; then 
-	mkdir -p /tmp/mnt
-	echo "Mounting ${DISK}"
-	mount -t apfs ${DISK} /tmp/mnt 
-	if [ $? -ne 0 ]; then
-		echo "failed to mount volume";
-		exit 1
-	fi
-	if [ -e /tmp/mnt/nand ]; then
-		echo "Nand image already downloaded."
-	else
-		rm -rf /tmp/mnt/nand
-		echo "Starting to download nand. This will take a few minutes"
-		wget http://assets.checkra.in/downloads/sandcastle/88b1089d97fe72ab77af8253ab7c312f8e789d49209234239be2408c3ad89a34/nand.gz -O /tmp/mnt/nand.gz
-		if [ $? -ne 0 ]; then
-			echo "Failed to download nand. Are you connected to wifi?"
-			umount /tmp/mnt
-			exit 1;
-		fi
-		echo "Decompressing nand image"
-		gunzip -d /tmp/mnt/nand.gz
-		if [ $? -ne 0 ]; then
-			echo "Failed to decompress nand. Wifi disconnected? gzip not installed?"
-			echo "unmounting /tmp/mnt"
-			umount /tmp/mnt
-			exit 1;
-		fi
-		sync
-	fi
-	echo "Applying touchscreen/WiFi patch and copying driver files."
-	
-	# The Hack.
-	echo -n "  " | dd bs=1 seek=1145078249 count=2 status=none conv=notrunc of=/tmp/mnt/nand
-	
-	# The Fix.
-	mkdir -p /tmp/mnt/usr/share/firmware/
-	cp -rn /usr/share/firmware/* /tmp/mnt/usr/share/firmware/
-	
-	umount /tmp/mnt
-	echo "unmounted /tmp/mnt"
-else
-	echo "disk not found somehow?"
+if [ ! -b ${DISK} ]; then 
+	echo "Android volume not found. This should have been caught earlier"
 	exit 1
 fi
+
+echo "Mounting ${DISK}"
+mkdir -p /tmp/mnt
+mount -t apfs ${DISK} /tmp/mnt 
+if [ $? -ne 0 ]; then
+	echo "failed to mount volume. Are you running as root?";
+	exit 1
+fi
+
+if [ -e /tmp/mnt/nand ]; then
+	echo "Nand image already downloaded."
+else
+	rm -rf /tmp/mnt/nand
+	echo "Starting to download nand. This will take a few minutes"
+	wget http://assets.checkra.in/downloads/sandcastle/88b1089d97fe72ab77af8253ab7c312f8e789d49209234239be2408c3ad89a34/nand.gz -O /tmp/mnt/nand.gz
+	if [ $? -ne 0 ]; then
+		echo "Failed to download nand. Are you connected to wifi?"
+		umount /tmp/mnt
+		echo "unmounted /tmp/mnt"
+		exit 1
+	fi
+	echo "Decompressing nand image"
+	gunzip -d /tmp/mnt/nand.gz
+	if [ $? -ne 0 ]; then
+		echo "Failed to decompress nand. Network interrupted? gzip not installed?"
+		umount /tmp/mnt
+		echo "unmounted /tmp/mnt"
+		exit 1
+	fi
+	sync
+fi
+
+echo "Applying touchscreen/WiFi patch and copying driver files."
+
+# The Hack.
+echo -n "  " | dd bs=1 seek=1145078249 count=2 status=none conv=notrunc of=/tmp/mnt/nand
+
+# The Fix.
+mkdir -p /tmp/mnt/usr/share/firmware/
+cp -rn /usr/share/firmware/* /tmp/mnt/usr/share/firmware/
+
+umount /tmp/mnt
+echo "unmounted /tmp/mnt"

--- a/isetup
+++ b/isetup
@@ -1,16 +1,17 @@
-#!/bin/sh
+#!/bin/bash
 
 DISK=0
-DISKS=`ls /dev/disk0s1s*`
-DISKS=`ls /dev/disk0s1s*`
+DISKS=`ls -U /dev/disk0s1s*`
+echo "disks: $DISKS"
 
 for i in ${DISKS}
 do
 	LABEL=`/System/Library/Filesystems/apfs.fs/apfs.util -p $i`
 	if [ "${LABEL}" == "Android" ]; then
-	    DISK=$i
-	    break;
-        fi
+		DISK=$i
+		echo "found an Android volume"
+		break;
+	fi
 done
 if [ ! -b ${DISK} ]; then
 	newfs_apfs -A -v Android -e /dev/disk0s1
@@ -23,37 +24,54 @@ for i in ${DISKS}
 do
 	LABEL=`/System/Library/Filesystems/apfs.fs/apfs.util -p $i`
 	if [ "${LABEL}" == "Android" ]; then
-	    DISK=$i
-	    break;
-        fi
+		if [ $i != "/dev/disk0s1s10" ]; then
+			DISK=$i
+			echo "found volume $i"
+			break;
+		fi
+	fi
 done
 if [ -b ${DISK} ]; then 
 	mkdir -p /tmp/mnt
 	echo "Mounting ${DISK}"
 	mount -t apfs ${DISK} /tmp/mnt 
 	if [ $? -ne 0 ]; then
-            echo "failed to mount disk";
-  	    exit 1
-        fi
-	rm -rf /tmp/mnt/nand*
-	echo "Starting to download nand. This will take a few minutes"
-	wget http://assets.checkra.in/downloads/sandcastle/88b1089d97fe72ab77af8253ab7c312f8e789d49209234239be2408c3ad89a34/nand.gz        
-	if [ $? -ne 0 ]; then
-		echo "Failed to download nand. Are you connected to wifi?"
-	        umount /tmp/mnt
-		exit 1;
+		echo "failed to mount volume";
+		exit 1
 	fi
-	echo "Decompressing nand image"
-	mv /var/root/nand.gz /tmp/mnt
-	gunzip -d /tmp/mnt/nand.gz
-        if [ $? -ne 0 ]; then
-                echo "Failed to decompress nand. Wifi disconnected?"
-                umount /tmp/mnt
-                exit 1;
-        fi
-	sync
+	if [ -e /tmp/mnt/nand ]; then
+		echo "Nand image already downloaded."
+	else
+		rm -rf /tmp/mnt/nand
+		echo "Starting to download nand. This will take a few minutes"
+		wget http://assets.checkra.in/downloads/sandcastle/88b1089d97fe72ab77af8253ab7c312f8e789d49209234239be2408c3ad89a34/nand.gz -O /tmp/mnt/nand.gz
+		if [ $? -ne 0 ]; then
+			echo "Failed to download nand. Are you connected to wifi?"
+			umount /tmp/mnt
+			exit 1;
+		fi
+		echo "Decompressing nand image"
+		gunzip -d /tmp/mnt/nand.gz
+		if [ $? -ne 0 ]; then
+			echo "Failed to decompress nand. Wifi disconnected? gzip not installed?"
+			echo "unmounting /tmp/mnt"
+			umount /tmp/mnt
+			exit 1;
+		fi
+		sync
+	fi
+	echo "Applying touchscreen/WiFi patch and copying driver files."
+	
+	# The Hack.
+	echo -n "  " | dd bs=1 seek=1145078249 count=2 status=none conv=notrunc of=/tmp/mnt/nand
+	
+	# The Fix.
+	mkdir -p /tmp/mnt/usr/share/firmware/
+	cp -rn /usr/share/firmware/* /tmp/mnt/usr/share/firmware/
+	
 	umount /tmp/mnt
+	echo "unmounted /tmp/mnt"
 else
-	echo "There was an error"
+	echo "disk not found somehow?"
 	exit 1
 fi

--- a/start_linux.sh
+++ b/start_linux.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+if [ "$EUID" -ne 0 ]; then
+	echo "Please run as root."
+	exit 1
+fi
+
+export DYLD_LIBRARY_PATH=./
+
+# dir is just the current directory?
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "$DIR"
+
+export CHECKRA1N_LOG_PATH=$PWD/out.log
+echo "$CHECKRA1N_LOG_PATH"
+# remove output log
+rm -rf "$CHECKRA1N_LOG_PATH"
+
+#not very important
+#killall -9 checkra1n > /dev/null 2>&1
+
+BOOT=0
+FOUND=0
+
+#${CHECKRA1N} -cp > /dev/null 2>&1 &
+#disown
+echo "Please run 'cd $PWD && sudo env CHECKRA1N_LOG_PATH=$CHECKRA1N_LOG_PATH ./checkra1n-0.10.1-x86_64 -cp' and put your device into DFU"
+sleep 1;
+while true; do
+    grep "Booting..." ${CHECKRA1N_LOG_PATH} > /dev/null 2>&1
+    if [ $? -eq 0 ]; then
+		BOOT=1
+		echo "Pongo loaded. Give it a second"
+		sleep 10;
+		break
+    fi
+    grep "DFU mode device found" ${CHECKRA1N_LOG_PATH} > /dev/null 2>&1
+    if [ $? -eq 0 ] && [ ${FOUND} -eq 0 ]; then
+        echo "Found DFU device. Starting"
+		FOUND=1
+    fi
+    sleep 1
+done
+if [ ${BOOT} -eq 1 ]; then
+	sleep 5;
+	echo "Starting Android"
+	./load-linux Android.lzma dtbpack
+fi
+#killall -9 checkra1n
+echo "you can now stop checkra1n"


### PR DESCRIPTION
Here's the touchscreen fix.

The touchscreen driver on Android needs firmware/settings for the touchscreen, but that's copyrighted by apple afaik. To work around that, Sandcastle loads that from the iOS volume on the device. iOS seems to have changed the apfs layout/format enough to confuse the apfs driver on Android, which means the touchscreen driver can't access it's files. This works around that by mounting the Android volume (which works with the android apfs driver) instead of the main iOS volume, and copies the firmware there. This also fixes the WiFi, which nobody seems to have noticed.

Known issues: Bluetooth is still broken.